### PR TITLE
More float FOV fixes

### DIFF
--- a/MoarCamz/MoarCamzPlugin.cs
+++ b/MoarCamz/MoarCamzPlugin.cs
@@ -395,7 +395,7 @@ namespace MoarCamz
             });
             FOV.onEndEdit.AddListener((s) =>
             {
-                if (int.TryParse(s, out int d))
+                if (float.TryParse(s, out float d))
                 {
                     SetFOV(d);
 #if !KK
@@ -747,7 +747,7 @@ namespace MoarCamz
 
                         if (!FOV.isFocused)
                         {
-                            FOV.text = string.Format("{0}", Studio.Studio.Instance.cameraCtrl.cameraData.parse);
+                            FOV.text = string.Format("{0:F1}", Studio.Studio.Instance.cameraCtrl.cameraData.parse);
                             FOVSlider.value = Studio.Studio.Instance.cameraCtrl.cameraData.parse;
                         }
                         


### PR DESCRIPTION
I came here because of the same bug as https://github.com/OrangeSpork/MoarCamz/pull/1
While that PR allows setting a float FOV while the UI is open, the interaction with the UI itself is broken
This PR should fix the int leftovers, but it also requires patching the FOV input in the unity3d asset to allow for float input
While I seem to have done it by modifying parameters in the asset, it's probably better if you modify the source and create a new one